### PR TITLE
dotenv parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
-# dotenv-rawan
+# dotenv file Parser
+
+This repository implements a .env file parser, handling invalid .env formats
+
+## In this README 👇
+
+- [Features](#features)
+- [Usage](#usage)
+
+## Features
+ - `Parse(path string)` takes the .env file path, loads and parses them into a map of key-value pairs
+
+## Usage
+
+1. 
+    ```go
+        import github.com/codescalersinternships/dotenv-rawan
+    ```
+
+
+2. Example usage:
+    ```go
+        envs, err := Parse(filePath)
+			if err != nil {
+				return err
+		}
+    ```
+
+

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/codescalersinternships/dotenv-rawan
+
+go 1.25.0

--- a/pkg/dotenvParser.go
+++ b/pkg/dotenvParser.go
@@ -1,0 +1,73 @@
+package dotenvParser
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+)
+
+var ErrUnsupporteFileType = errors.New("file type is not supported")
+var ErrFileNotExist = errors.New("file doesn't exist")
+var ErrEmptyFile = errors.New("file is empty")
+
+var ErrInvalidSyntax = errors.New("invalid dotenv syntax")
+
+func loadEnv(path string) (string, error) {
+	if !strings.HasSuffix(path, ".env") {
+		return "", ErrUnsupporteFileType
+	}
+
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return "", ErrFileNotExist
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+
+	return string(data), nil
+}
+
+func Parse(path string) (map[string]string, error) {
+
+	data, err := loadEnv(path)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if len(data) == 0 {
+		return nil, ErrEmptyFile
+	}
+
+	envVars := make(map[string]string)
+
+	lines := strings.Split(data, "\n")
+
+	for i, line := range lines {
+		line = strings.TrimSpace(line)
+
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		parts := strings.SplitN(line, "=", 2)
+
+		if len(parts) < 2 {
+			return nil, fmt.Errorf("%w on line %d", ErrInvalidSyntax, i+1)
+		}
+
+		if cut, ok := strings.CutPrefix(parts[0], "export"); ok {
+			parts[0] = cut
+		}
+
+		key := strings.TrimSpace(parts[0])
+		value := strings.TrimSpace(parts[1])
+
+		envVars[key] = value
+	}
+
+	return envVars, nil
+}

--- a/pkg/dotenvParser.go
+++ b/pkg/dotenvParser.go
@@ -2,7 +2,6 @@ package dotenvParser
 
 import (
 	"errors"
-	"fmt"
 	"os"
 	"strings"
 )
@@ -11,7 +10,10 @@ var ErrUnsupporteFileType = errors.New("file type is not supported")
 var ErrFileNotExist = errors.New("file doesn't exist")
 var ErrEmptyFile = errors.New("file is empty")
 
-var ErrInvalidSyntax = errors.New("invalid dotenv syntax")
+var ErrNoEqual = errors.New("syntax error: line must have an equal sign")
+var ErrMissingKey = errors.New("syntax error: missing key")
+var ErrMissingValue = errors.New("syntax error: missing Value")
+var ErrKeyName = errors.New("syntax error: invalid key name")
 
 func loadEnv(path string) (string, error) {
 	if !strings.HasSuffix(path, ".env") {
@@ -31,12 +33,18 @@ func loadEnv(path string) (string, error) {
 }
 
 func Parse(path string) (map[string]string, error) {
-
 	data, err := loadEnv(path)
 
 	if err != nil {
 		return nil, err
 	}
+
+	got, err := parseString(data)
+
+	return got, err
+}
+
+func parseString(data string) (map[string]string, error) {
 
 	if len(data) == 0 {
 		return nil, ErrEmptyFile
@@ -46,7 +54,7 @@ func Parse(path string) (map[string]string, error) {
 
 	lines := strings.Split(data, "\n")
 
-	for i, line := range lines {
+	for _, line := range lines {
 		line = strings.TrimSpace(line)
 
 		if line == "" || strings.HasPrefix(line, "#") {
@@ -56,7 +64,7 @@ func Parse(path string) (map[string]string, error) {
 		parts := strings.SplitN(line, "=", 2)
 
 		if len(parts) < 2 {
-			return nil, fmt.Errorf("%w on line %d", ErrInvalidSyntax, i+1)
+			return nil, ErrNoEqual
 		}
 
 		if cut, ok := strings.CutPrefix(parts[0], "export"); ok {
@@ -65,6 +73,18 @@ func Parse(path string) (map[string]string, error) {
 
 		key := strings.TrimSpace(parts[0])
 		value := strings.TrimSpace(parts[1])
+
+		if key == "" {
+			return nil, ErrMissingKey
+		}
+
+		if value == "" {
+			return nil, ErrMissingValue
+		}
+
+		if strings.Contains(key, " ") {
+			return nil, ErrKeyName
+		}
 
 		envVars[key] = value
 	}

--- a/pkg/dotenvParser_test.go
+++ b/pkg/dotenvParser_test.go
@@ -1,0 +1,69 @@
+package dotenvParser
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		name     string
+		filePath string
+		expected map[string]string
+		err      error
+	}{
+		{
+			name:     "Valid .env file",
+			filePath: "testdata/.env",
+			expected: map[string]string{
+				"APP_NAME":       "Linktree",
+				"APP_ENV":        "development",
+				"APP_PORT":       "8080",
+				"DB_HOST":        "localhost",
+				"DB_PORT":        "5432",
+				"DB_USER":        "admin",
+				"DB_PASSWORD":    "secretpassword",
+				"DB_NAME":        "linktree_db",
+				"JWT_SECRET":     "my_super_secret_key",
+				"JWT_EXPIRATION": "3600",
+				"API_KEY":        "123456789abcdef",
+				"API_URL":        "https://api.example.com",
+				"DEBUG":          "true",
+				"CACHE_ENABLED":  "false",
+			},
+			err: nil,
+		},
+		{
+			name:     "Unsupported file type",
+			filePath: "testdata/env.txt",
+			expected: nil,
+			err:      ErrUnsupporteFileType,
+		},
+		{
+			name:     "Non-existent file",
+			filePath: "testdata/nonexistent.env",
+			expected: nil,
+			err:      ErrFileNotExist,
+		},
+		{
+			name:     "Empty .env file",
+			filePath: "testdata/empty.env",
+			expected: nil,
+			err:      ErrEmptyFile,
+		},
+	}
+
+	for _, testcase := range tests {
+		t.Run(testcase.name, func(t *testing.T) {
+			got, err := Parse(testcase.filePath)
+
+			if err != testcase.err {
+				t.Errorf("expected error: %v, got: %v", testcase.err, err)
+			}
+
+			if !reflect.DeepEqual(got, testcase.expected) {
+				t.Fatalf("mismatch:\nexpected: %#v\ngot: %#v", testcase.expected, got)
+			}
+		})
+	}
+}

--- a/pkg/dotenvParser_test.go
+++ b/pkg/dotenvParser_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func TestParse(t *testing.T) {
+func TestParseFile(t *testing.T) {
 	tests := []struct {
 		name     string
 		filePath string
@@ -56,6 +56,54 @@ func TestParse(t *testing.T) {
 	for _, testcase := range tests {
 		t.Run(testcase.name, func(t *testing.T) {
 			got, err := Parse(testcase.filePath)
+
+			if err != testcase.err {
+				t.Errorf("expected error: %v, got: %v", testcase.err, err)
+			}
+
+			if !reflect.DeepEqual(got, testcase.expected) {
+				t.Fatalf("mismatch:\nexpected: %#v\ngot: %#v", testcase.expected, got)
+			}
+		})
+	}
+}
+
+func TestParseSyntaxErr(t *testing.T) {
+	tests := []struct {
+		name       string
+		fileString string
+		expected   map[string]string
+		err        error
+	}{
+		{
+			name:       "Missing Value",
+			fileString: "DB_HOST=",
+			expected:   nil,
+			err:        ErrMissingValue,
+		},
+		{
+			name:       "Missing Key",
+			fileString: "=12345",
+			expected:   nil,
+			err:        ErrMissingKey,
+		},
+		{
+			name:       "Space in Key",
+			fileString: "DB USER=admin",
+			expected:   nil,
+			err:        ErrKeyName,
+		},
+		{
+			name:       "No equal sign",
+			fileString: "DB_USER",
+			expected:   nil,
+			err:        ErrNoEqual,
+		},
+	}
+
+	for _, testcase := range tests {
+		t.Run(testcase.name, func(t *testing.T) {
+			got, err := parseString(testcase.fileString)
 
 			if err != testcase.err {
 				t.Errorf("expected error: %v, got: %v", testcase.err, err)

--- a/pkg/testdata/.env
+++ b/pkg/testdata/.env
@@ -1,0 +1,25 @@
+# Application settings
+APP_NAME=Linktree
+APP_ENV=development
+APP_PORT=8080
+
+# Database settings
+export DB_HOST=localhost
+DB_PORT=5432
+DB_USER=admin
+DB_PASSWORD=secretpassword
+export DB_NAME=linktree_db
+
+# JWT settings
+JWT_SECRET=my_super_secret_key
+JWT_EXPIRATION=3600
+
+# External API
+API_KEY=123456789abcdef
+API_URL=https://api.example.com
+
+# Boolean-like values
+DEBUG   =true
+CACHE_ENABLED=  false
+
+

--- a/pkg/testdata/env.txt
+++ b/pkg/testdata/env.txt
@@ -1,0 +1,3 @@
+APP_NAME=Linktree
+APP_ENV=development
+APP_PORT=8080


### PR DESCRIPTION
Issue Link: https://github.com/codescalersinternships/home/issues/316

This PR implements the following APIs for .env files parser and their unit tests:
 - `Parse(path string)` takes the .env file path, loads and parses them into a map of key-value pairs